### PR TITLE
fix: Fix Sequential Click Behavior for `click 1` Action

### DIFF
--- a/Sources/QuadrantView.swift
+++ b/Sources/QuadrantView.swift
@@ -168,6 +168,10 @@ enum MovementDirection {
 
 class QuadrantWindow: NSWindow {
     private var quadrantView: QuadrantView!
+    private var lastClickTime: Date?
+    private var lastClickPosition: CGPoint?
+    private var lastClickButton: CGMouseButton?
+    private var clickCount: Int = 0
 
     init(screen: NSScreen) {
         super.init(contentRect: screen.frame,
@@ -240,7 +244,7 @@ class QuadrantWindow: NSWindow {
         }
     }
 
-    func performClickAtCurrentMousePosition(button: CGMouseButton) {
+        func performClickAtCurrentMousePosition(button: CGMouseButton) {
         let currentMouseLocation = NSEvent.mouseLocation
 
         let globalScreenHeight = NSScreen.screens.map { $0.frame.maxY }.max() ?? (NSScreen.main?.frame.height ?? 0)
@@ -252,6 +256,23 @@ class QuadrantWindow: NSWindow {
         print("Current mouse location: \(currentMouseLocation)")
         print("Global screen height: \(globalScreenHeight)")
         print("Flipped screen point: \(flippedScreenPoint)")
+
+                let maxClickDistance: CGFloat = 6.0
+
+        if let lastPos = lastClickPosition,
+           let lastBtn = lastClickButton,
+           lastBtn == button {
+
+            let distance = sqrt(pow(flippedScreenPoint.x - lastPos.x, 2) + pow(flippedScreenPoint.y - lastPos.y, 2))
+
+            if distance <= maxClickDistance {
+                self.clickCount = min(self.clickCount + 1, 3)
+            } else {
+                self.clickCount = 1
+            }
+        } else {
+            self.clickCount = 1
+        }
 
         let (downEventType, upEventType): (CGEventType, CGEventType)
         switch button {
@@ -273,14 +294,20 @@ class QuadrantWindow: NSWindow {
         let releaseEvent = CGEvent(mouseEventSource: nil, mouseType: upEventType, mouseCursorPosition: flippedScreenPoint, mouseButton: button)
 
         if let click = clickEvent, let release = releaseEvent {
+            click.setIntegerValueField(.mouseEventClickState, value: Int64(self.clickCount))
             click.post(tap: CGEventTapLocation.cghidEventTap)
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.02) {
+                release.setIntegerValueField(.mouseEventClickState, value: Int64(self.clickCount))
                 release.post(tap: CGEventTapLocation.cghidEventTap)
             }
-            print("Click events posted at current mouse position")
+            print("Click events posted (count: \(self.clickCount)) at current mouse position")
         } else {
             print("Failed to create click events")
         }
+
+        lastClickTime = Date()
+        lastClickPosition = flippedScreenPoint
+        lastClickButton = button
     }
 
     func warpToSelectedArea() {
@@ -325,6 +352,14 @@ class QuadrantWindow: NSWindow {
     override func makeKeyAndOrderFront(_ sender: Any?) {
         super.makeKeyAndOrderFront(sender)
         quadrantView.resetToFullScreen()
+        resetClickTracking()
+    }
+
+    func resetClickTracking() {
+        lastClickTime = nil
+        lastClickPosition = nil
+        lastClickButton = nil
+        clickCount = 0
     }
 
     func performScrollUp() {

--- a/Sources/QuadrantView.swift
+++ b/Sources/QuadrantView.swift
@@ -266,7 +266,7 @@ class QuadrantWindow: NSWindow {
             let distance = sqrt(pow(flippedScreenPoint.x - lastPos.x, 2) + pow(flippedScreenPoint.y - lastPos.y, 2))
 
             if distance <= maxClickDistance {
-                self.clickCount = min(self.clickCount + 1, 3)
+                self.clickCount = self.clickCount + 1
             } else {
                 self.clickCount = 1
             }

--- a/Sources/main.swift
+++ b/Sources/main.swift
@@ -197,6 +197,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
     func hideQuadrantWindow() {
         guard let window = quadrantWindow else { return }
+        window.resetClickTracking()
         window.orderOut(nil)
         removeEventTap()
         currentQuadrantScreen = nil


### PR DESCRIPTION
## Fix Sequential Click Behavior for `click 1` Action

### Problem
The `click 1` action (pressing `1` key while overlay is active) was not properly handling sequential clicks. When users pressed `1` multiple times at the same location, it would generate separate single-click events instead of proper double-clicks, triple-clicks, etc. This prevented text selection in browsers and text editors where:
- First click: positions cursor
- Second click: selects word  
- Third click: selects line/paragraph

### Root Cause
The original implementation was creating individual mouse down/up events without proper click state tracking. Each press of `1` sent `clickState = 1` (single click) regardless of previous clicks, so the system never recognized them as part of a sequence.

### Solution
Implemented proper sequential click tracking by:

1. **Added click state tracking variables** to `QuadrantWindow`:
   - `lastClickTime`: Timestamp of previous click
   - `lastClickPosition`: Location of previous click  
   - `lastClickButton`: Which button was clicked
   - `clickCount`: Current sequential click count

2. **Enhanced click detection logic** in `performClickAtCurrentMousePosition()`:
   - Detects when clicks occur within 6 pixels of previous click
   - Increments click count for sequential clicks at same location
   - Resets count to 1 when clicking elsewhere

3. **Proper CGEvent generation** using `setIntegerValueField(.mouseEventClickState, value: clickCount)`:
   - First press: `clickState = 1` → positions cursor
   - Second press: `clickState = 2` → selects word (double-click)  
   - Third press: `clickState = 3` → selects line (triple-click)
   - Fourth+ press: `clickState = 4+` → unlimited sequential clicks

4. **State management**:
   - Click tracking resets when overlay is shown/hidden
   - Click tracking resets when switching monitors
   - No arbitrary limit on click count (can increment indefinitely)

### Behavior Changes
- ✅ **Before**: Pressing `1` twice → two separate single clicks → no text selection
- ✅ **After**: Pressing `1` twice at same location → proper double-click → selects word
- ✅ **After**: Pressing `1` three times → triple-click → selects line  
- ✅ **After**: Unlimited sequential clicks supported for applications with custom behaviors

### Testing
1. Activate macnav overlay (`Ctrl+Semicolon`)
2. Position mouse over text in browser/editor
3. Press `1` → cursor positions ✓
4. Press `1` again → word selects ✓  
5. Press `1` again → line selects ✓
6. Move mouse elsewhere and press `1` → resets to single click ✓

### Files Changed
- `Sources/QuadrantView.swift`: Added click tracking logic and proper CGEvent state management
- `Sources/main.swift`: Added click tracking reset when hiding overlay

This fix resolves issue #11 and provides the expected text selection behavior that users expect from keyboard-driven navigation tools.
